### PR TITLE
Feature/refactor address format stylesheet

### DIFF
--- a/l10n_jp_address_layout/README.rst
+++ b/l10n_jp_address_layout/README.rst
@@ -35,6 +35,7 @@ Contributors
 
 * Tim Lai <tl@quartile.co>
 * Yoshi Tashiro <tashiro@quartile.co>
+* Takuya Sawada <takuya@tuntunkun.com>
 
 Maintainer
 ----------

--- a/l10n_jp_address_layout/__manifest__.py
+++ b/l10n_jp_address_layout/__manifest__.py
@@ -16,6 +16,7 @@
 This module provides Japan address input field layout.
     """,
     'data': [
+        'views/assets.xml',
         'views/res_partner_views.xml',
         'data/res_country_data.xml',
     ],

--- a/l10n_jp_address_layout/static/src/less/form_view.less
+++ b/l10n_jp_address_layout/static/src/less/form_view.less
@@ -1,0 +1,20 @@
+.o_form_view {
+    .o_address_format {
+        &.o_zip_state_city {
+            .o_address_zip {
+                margin-right: 2%;
+            }
+            .o_address_city {
+                margin-right: 0;
+            }
+        }
+    }
+
+    &.o_form_editable .o_address_format {
+        &.o_zip_state_city {
+            .o_address_zip, .o_address_state, .o_address_city {
+                width: 32%;
+            }
+        }
+    }
+}

--- a/l10n_jp_address_layout/views/assets.xml
+++ b/l10n_jp_address_layout/views/assets.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="0">
+        <template id="assets_backend" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <link rel="stylesheet" type="text/less" href="/l10n_jp_address_layout/static/src/less/form_view.less"/>
+            </xpath>
+        </template>
+    </data>
+</odoo>
+

--- a/l10n_jp_address_layout/views/res_partner_views.xml
+++ b/l10n_jp_address_layout/views/res_partner_views.xml
@@ -6,14 +6,16 @@
         <field name="model">res.partner</field>
         <field name="arch" type="xml">
             <form>
-                <div class="o_address_format">
+                <div class="o_address_format o_zip_state_city">
                     <field name="type" invisible="1"/>
                     <field name="parent_id" invisible="1"/>
                     <div class="oe_edit_only">
                         <button name="open_parent" type="object" string="(edit)" class="oe_link" attrs="{'invisible': ['|', ('parent_id', '=', False), ('type', '!=', 'contact')]}"/>
                     </div>
-                    〒 <field name="zip" placeholder="ZIP" class="o_address_zip" attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                     <div>
+                        <span class="oe_read_only">〒</span>
+                        <field name="zip" placeholder="ZIP" class="o_address_zip" attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
+                        <br class="oe_read_only"/>
                         <field name="state_id" class="o_address_state" placeholder="State" options='{"no_open": True}' attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}" context="{'country_id': country_id, 'zip': zip}"/>
                         <field name="city" placeholder="City" class="o_address_city" attrs="{'readonly': [('type', '=', 'contact'),('parent_id', '!=', False)]}"/>
                     </div>


### PR DESCRIPTION
I refactor the style sheet related to the address format.
Just look these images...

#### BEFORE
![before](https://user-images.githubusercontent.com/1128403/38159871-11384b32-34ed-11e8-8d84-2ad8f9097850.png)

#### AFTER
![after](https://user-images.githubusercontent.com/1128403/38159875-2a442e7a-34ed-11e8-9f9d-2e02822cc6a3.png)
From now on, Japanese zip code symbol "〒" is not shown in editing mode (readonly).
It seems the height of drop-down list (state) is shorter than other fields, but i think this is another issue of odoo style sheet.