### PR TITLE
Extend default contact widget, allowing title of res.partner to be shown

### DIFF
--- a/l10n_jp_address_layout/__init__.py
+++ b/l10n_jp_address_layout/__init__.py
@@ -1,1 +1,3 @@
 # -*- coding: utf-8 -*-
+
+from . import models

--- a/l10n_jp_address_layout/__manifest__.py
+++ b/l10n_jp_address_layout/__manifest__.py
@@ -3,7 +3,7 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     'name': 'Japan Address Layout',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.1.0',
     'depends': [
         'base',
     ],
@@ -13,12 +13,17 @@
     'website': 'https://odoo-community.org/',
     'category': 'Extra Tools',
     'description': """
-This module provides Japan address input field layout.
+This module provides Japan address input field layout in views
+The module also extends the default partner title model, allowing the title
+to be shown in most printed reports.
     """,
     'data': [
         'views/assets.xml',
+        'views/res_partner_title_views.xml',
         'views/res_partner_views.xml',
+        'views/templates.xml',
         'data/res_country_data.xml',
+        'data/res_partner_title_data.xml',
     ],
     'installable': True,
 }

--- a/l10n_jp_address_layout/data/res_partner_title_data.xml
+++ b/l10n_jp_address_layout/data/res_partner_title_data.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<odoo noupdate="1">
+
+    <record id="res_partner_title_sama" model="res.partner.title">
+        <field name="name">様</field>
+        <field name="shortcut">様</field>
+        <field name="title_position">after</field>
+    </record>
+
+    <record id="res_partner_title_onchuu" model="res.partner.title">
+        <field name="name">御中</field>
+        <field name="shortcut">御中</field>
+        <field name="title_position">after</field>
+    </record>
+
+</odoo>

--- a/l10n_jp_address_layout/data/res_partner_title_data.xml
+++ b/l10n_jp_address_layout/data/res_partner_title_data.xml
@@ -4,13 +4,13 @@
     <record id="res_partner_title_sama" model="res.partner.title">
         <field name="name">様</field>
         <field name="shortcut">様</field>
-        <field name="title_position">after</field>
+        <field name="display_position">after</field>
     </record>
 
     <record id="res_partner_title_onchuu" model="res.partner.title">
         <field name="name">御中</field>
         <field name="shortcut">御中</field>
-        <field name="title_position">after</field>
+        <field name="display_position">after</field>
     </record>
 
 </odoo>

--- a/l10n_jp_address_layout/i18n/ja_JP.po
+++ b/l10n_jp_address_layout/i18n/ja_JP.po
@@ -53,7 +53,7 @@ msgstr "都道府県/州"
 #. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
 msgid "State"
-msgstr "都道府県・州"
+msgstr "都道府県/州"
 
 #. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form

--- a/l10n_jp_address_layout/i18n/ja_JP.po
+++ b/l10n_jp_address_layout/i18n/ja_JP.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-01-02 07:50+0000\n"
-"PO-Revision-Date: 2018-01-02 07:50+0000\n"
+"POT-Creation-Date: 2018-04-13 06:55+0000\n"
+"PO-Revision-Date: 2018-04-13 06:55+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,6 +21,16 @@ msgid "(edit)"
 msgstr "(編集)"
 
 #. module: l10n_jp_address_layout
+#: selection:res.partner.title,title_position:0
+msgid "After Name"
+msgstr "名前の後"
+
+#. module: l10n_jp_address_layout
+#: selection:res.partner.title,title_position:0
+msgid "Before Name"
+msgstr "名前の前"
+
+#. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
 msgid "City"
 msgstr "市区町村"
@@ -29,11 +39,6 @@ msgstr "市区町村"
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
 msgid "Country"
 msgstr "国"
-
-#. module: l10n_jp_address_layout
-#: model:ir.model,name:l10n_jp_address_layout.model_res_country_state
-msgid "Country state"
-msgstr "都道府県/州"
 
 #. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
@@ -51,6 +56,24 @@ msgid "Street..."
 msgstr "町名番地…"
 
 #. module: l10n_jp_address_layout
+#: model:ir.model.fields,field_description:l10n_jp_address_layout.field_res_partner_title_title_position
+msgid "Title Position"
+msgstr "タイトル位置"
+
+#. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
 msgid "ZIP"
 msgstr "郵便番号"
+
+#. module: l10n_jp_address_layout
+#: model:ir.model,name:l10n_jp_address_layout.model_res_partner_title
+msgid "res.partner.title"
+msgstr "res.partner.title"
+
+#. module: l10n_jp_address_layout
+#: model:res.partner.title,name:l10n_jp_address_layout.res_partner_title_onchuu
+#: model:res.partner.title,shortcut:l10n_jp_address_layout.res_partner_title_onchuu
+msgid "御中"
+msgstr "御中"
+
+

--- a/l10n_jp_address_layout/i18n/ja_JP.po
+++ b/l10n_jp_address_layout/i18n/ja_JP.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-13 06:55+0000\n"
-"PO-Revision-Date: 2018-04-13 06:55+0000\n"
+"POT-Creation-Date: 2018-04-13 09:01+0000\n"
+"PO-Revision-Date: 2018-04-13 09:01+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,12 +21,12 @@ msgid "(edit)"
 msgstr "(編集)"
 
 #. module: l10n_jp_address_layout
-#: selection:res.partner.title,title_position:0
+#: selection:res.partner.title,display_position:0
 msgid "After Name"
 msgstr "名前の後"
 
 #. module: l10n_jp_address_layout
-#: selection:res.partner.title,title_position:0
+#: selection:res.partner.title,display_position:0
 msgid "Before Name"
 msgstr "名前の前"
 
@@ -41,6 +41,11 @@ msgid "Country"
 msgstr "国"
 
 #. module: l10n_jp_address_layout
+#: model:ir.model.fields,field_description:l10n_jp_address_layout.field_res_partner_title_display_position
+msgid "Display Position"
+msgstr "表示位置"
+
+#. module: l10n_jp_address_layout
 #: model:ir.model,name:l10n_jp_address_layout.model_res_country_state
 msgid "Country state"
 msgstr "都道府県/州"
@@ -48,7 +53,7 @@ msgstr "都道府県/州"
 #. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
 msgid "State"
-msgstr "都道府県/州"
+msgstr "都道府県・州"
 
 #. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
@@ -59,11 +64,6 @@ msgstr "町名番地2…"
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
 msgid "Street..."
 msgstr "町名番地…"
-
-#. module: l10n_jp_address_layout
-#: model:ir.model.fields,field_description:l10n_jp_address_layout.field_res_partner_title_title_position
-msgid "Title Position"
-msgstr "タイトル位置"
 
 #. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form

--- a/l10n_jp_address_layout/i18n/ja_JP.po
+++ b/l10n_jp_address_layout/i18n/ja_JP.po
@@ -41,6 +41,11 @@ msgid "Country"
 msgstr "国"
 
 #. module: l10n_jp_address_layout
+#: model:ir.model,name:l10n_jp_address_layout.model_res_country_state
+msgid "Country state"
+msgstr "都道府県/州"
+
+#. module: l10n_jp_address_layout
 #: model:ir.ui.view,arch_db:l10n_jp_address_layout.res_partner_japan_address_form
 msgid "State"
 msgstr "都道府県/州"

--- a/l10n_jp_address_layout/models/__init__.py
+++ b/l10n_jp_address_layout/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import res_partner_title

--- a/l10n_jp_address_layout/models/res_partner_title.py
+++ b/l10n_jp_address_layout/models/res_partner_title.py
@@ -8,7 +8,7 @@ from odoo import models, fields
 class ResPartnerTitle(models.Model):
     _inherit = 'res.partner.title'
 
-    title_position = fields.Selection(
+    display_position = fields.Selection(
         [('before', "Before Name"), ('after', "After Name")],
-        string='Title Position',
+        string='Display Position',
     )

--- a/l10n_jp_address_layout/models/res_partner_title.py
+++ b/l10n_jp_address_layout/models/res_partner_title.py
@@ -10,5 +10,5 @@ class ResPartnerTitle(models.Model):
 
     title_position = fields.Selection(
         [('before', "Before Name"), ('after', "After Name")],
-        string= 'Title Position',
+        string='Title Position',
     )

--- a/l10n_jp_address_layout/models/res_partner_title.py
+++ b/l10n_jp_address_layout/models/res_partner_title.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import models, fields
+
+
+class ResPartnerTitle(models.Model):
+    _inherit = 'res.partner.title'
+
+    title_position = fields.Selection(
+        [('before', "Before Name"), ('after', "After Name")],
+        string= 'Title Position',
+    )

--- a/l10n_jp_address_layout/views/res_partner_title_views.xml
+++ b/l10n_jp_address_layout/views/res_partner_title_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<odoo>
+
+    <record id="view_partner_title_tree" model="ir.ui.view">
+        <field name="name">res.partner.title.tree</field>
+        <field name="model">res.partner.title</field>
+        <field name="inherit_id" ref="base.view_partner_title_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='shortcut']" position="after">
+                <field name="title_position"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_partner_title_form" model="ir.ui.view">
+        <field name="name">res.partner.title.form</field>
+        <field name="model">res.partner.title</field>
+        <field name="inherit_id" ref="base.view_partner_title_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='shortcut']" position="after">
+                <field name="title_position"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_jp_address_layout/views/res_partner_title_views.xml
+++ b/l10n_jp_address_layout/views/res_partner_title_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="base.view_partner_title_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='shortcut']" position="after">
-                <field name="title_position"/>
+                <field name="display_position"/>
             </xpath>
         </field>
     </record>
@@ -18,7 +18,7 @@
         <field name="inherit_id" ref="base.view_partner_title_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='shortcut']" position="after">
-                <field name="title_position"/>
+                <field name="display_position"/>
             </xpath>
         </field>
     </record>

--- a/l10n_jp_address_layout/views/res_partner_views.xml
+++ b/l10n_jp_address_layout/views/res_partner_views.xml
@@ -27,4 +27,15 @@
         </field>
     </record>
 
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">view.partner.form</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='title']" position="attributes">
+                <attribute name="attrs"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/l10n_jp_address_layout/views/templates.xml
+++ b/l10n_jp_address_layout/views/templates.xml
@@ -3,12 +3,12 @@
 
     <template id="contact_name" inherit_id="base.contact_name" >
         <xpath expr="//t[@t-if='object.name']" position="before">
-            <t t-if="object.title and object.title.title_position and object.title.title_position == 'before'">
+            <t t-if="object.title and object.title.display_position and object.title.display_position == 'before'">
                 <span itemprop="title" t-esc="object.title.name"/>
             </t>
         </xpath>
         <xpath expr="//div" position="inside">
-            <t t-if="object.title and object.title.title_position and object.title.title_position == 'after'">
+            <t t-if="object.title and object.title.display_position and object.title.display_position == 'after'">
                 <span itemprop="title" t-esc="object.title.name"/>
             </t>
         </xpath>

--- a/l10n_jp_address_layout/views/templates.xml
+++ b/l10n_jp_address_layout/views/templates.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="contact_name" inherit_id="base.contact_name" >
+        <xpath expr="//t[@t-if='object.name']" position="before">
+            <t t-if="object.title and object.title.title_position and object.title.title_position == 'before'">
+                <span itemprop="title" t-esc="object.title.name"/>
+            </t>
+        </xpath>
+        <xpath expr="//div" position="inside">
+            <t t-if="object.title and object.title.title_position and object.title.title_position == 'after'">
+                <span itemprop="title" t-esc="object.title.name"/>
+            </t>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
Background:
For most Japanese documents, title "様" / ”御中” will be put in the end of customer's / company's name.
This PR will add these two special titles record to `res.partner.title` and extend the model to allow adjusting the display position of the title in the contact widget.