### PR TITLE
[16.0][FIX] account_payment_term_cutoff_day: fix not changing to end of month

### DIFF
--- a/account_payment_term_cutoff_day/models/account_payment_term_line.py
+++ b/account_payment_term_cutoff_day/models/account_payment_term_line.py
@@ -19,9 +19,8 @@ class AccountPaymentTermLine(models.Model):
     )
 
     def _get_due_date(self, date_ref):
-        due_date = super()._get_due_date(date_ref)
         if date_ref and self.end_month and self.cutoff_day:
             date_dt = fields.Date.to_date(date_ref)
             if date_dt.day > self.cutoff_day:
-                due_date += relativedelta(months=1)
-        return due_date
+                date_ref += relativedelta(months=1)
+        return super()._get_due_date(date_ref)

--- a/account_payment_term_cutoff_day/tests/test_account_invoice_date_due.py
+++ b/account_payment_term_cutoff_day/tests/test_account_invoice_date_due.py
@@ -45,6 +45,17 @@ class TestPaymentTermCutoffDate(TransactionCase):
             expected_due_date,
         )
 
+    def test_due_date_after_cutoff_day_with_31_days(self):
+        """Test if due date is shifted by +1 month and the following month has 31 days
+        when invoice date is after cutoff_day"""
+        invoice_date = date(2025, 1, 31)
+        expected_due_date = date(2025, 3, 31)
+        computed_due_date = self.payment_term_line._get_due_date(invoice_date)
+        self.assertEqual(
+            computed_due_date,
+            expected_due_date,
+        )
+
     def test_due_date_no_cutoff_day(self):
         """Test if due date remains unchanged when cutoff_day is not set"""
         self.payment_term_line.cutoff_day = False


### PR DESCRIPTION
Before this PR, automatically shifting the due date by one month did not account for the end of the month. For example, if the original due date was the 30th and the following month had 31 days, the new due date would incorrectly be set to the 30th instead of the 31st.

@qrtl QT5376