### PR TITLE
[16.0][FIX] report_alternative_layout: hide group unless alternative layout

### DIFF
--- a/report_alternative_layout/models/ir_actions_report.py
+++ b/report_alternative_layout/models/ir_actions_report.py
@@ -16,12 +16,25 @@ class Report(models.Model):
         "Show Remit-to Bank",
         help="If selected, remit-to bank account will show in the report output.",
     )
-    show_document_number = fields.Boolean()
+    show_document_number = fields.Boolean(
+        "Show Document Number in Header",
+        help="If selected, the document number will show in the report header.",
+    )
     date_field_id = fields.Many2one(
         "ir.model.fields",
         domain="[('model','=', model), ('ttype', 'in', ('date', 'datetime'))]",
+        string="Date Field to Show in Header",
+        help="If set, the report will show the value of this field in the header as "
+        "the date of the document.",
     )
-    date_field_label = fields.Char(translate=True)
+    date_field_label = fields.Char(
+        translate=True,
+        help="Label for the date field in the report header. If not set, the field's "
+        "description will be used.",
+    )
+    apply_alternative_layout = fields.Boolean(
+        related="paperformat_id.apply_alternative_layout"
+    )
 
     def _render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         report = self._get_report(report_ref)

--- a/report_alternative_layout/views/ir_actions_report_views.xml
+++ b/report_alternative_layout/views/ir_actions_report_views.xml
@@ -4,17 +4,28 @@
         <field name="model">ir.actions.report</field>
         <field name="inherit_id" ref="base.act_report_xml_view" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='name']/../.." position="inside">
-                <group>
-                    <field name="show_commercial_partner" />
-                    <field name="show_remit_to_bank" />
-                    <field name="show_document_number" />
-                    <field name="date_field_id" />
-                    <field
-                        name="date_field_label"
-                        attrs="{'invisible': [('date_field_id', '=', False)]}"
-                    />
-                </group>
+            <xpath expr="//notebook" position="inside">
+                <field name="apply_alternative_layout" invisible="1" />
+                <page
+                    name="alternative"
+                    string="Alternative Layout Settings"
+                    attrs="{'invisible': [('apply_alternative_layout', '!=', True)]}"
+                >
+                    <group>
+                        <group>
+                            <field name="show_document_number" />
+                            <field name="date_field_id" />
+                            <field
+                                name="date_field_label"
+                                attrs="{'invisible': [('date_field_id', '=', False)]}"
+                            />
+                        </group>
+                        <group>
+                            <field name="show_remit_to_bank" />
+                            <field name="show_commercial_partner" />
+                        </group>
+                    </group>
+                </page>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Only display the additional layout options group in the report form view when the related paperformat's `apply_alternative_layout` is enabled.

@qrtl QT5426