### PR TITLE
[16.0][FIX] l10n_jp_summary_invoice

### DIFF
--- a/l10n_jp_summary_invoice/models/__init__.py
+++ b/l10n_jp_summary_invoice/models/__init__.py
@@ -1,5 +1,6 @@
 from . import account_billing
 from . import account_move
+from . import account_move_line
 from . import account_tax_group
 from . import account_tax
 from . import res_company

--- a/l10n_jp_summary_invoice/models/account_billing.py
+++ b/l10n_jp_summary_invoice/models/account_billing.py
@@ -82,25 +82,33 @@ class AccountBilling(models.Model):
         "currency_id",
     )
     def _compute_tax_totals(self):
+        """Compute `tax_totals` by building an in-memory draft invoice that reuses all
+        the invoice lines referenced by the billing lines, and then delegating the tax
+        calculation to Odoo's standard `account.move._compute_tax_totals()`.
+        """
         for bill in self:
-            invoice_lines = bill.billing_line_ids.move_id.invoice_line_ids
-            base_lines = invoice_lines.filtered(
-                lambda line: line.display_type == "product"
+            src_moves = bill.billing_line_ids.move_id
+            move_type = "out_invoice"
+            if src_moves.filtered(lambda m: m.move_type in ["in_invoice", "in_refund"]):
+                move_type = "in_invoice"
+            src_lines = src_moves.invoice_line_ids
+            cmd_lines = []
+            for src_line in src_lines:
+                vals = src_line.copy_data()[0]
+                vals["quantity"] *= -src_line.move_id.direction_sign
+                cmd_lines.append(Command.create(vals))
+            # Build a transient invoice holding those lines
+            dummy_move = self.env["account.move"].new(
+                {
+                    "move_type": move_type,
+                    "company_id": bill.company_id.id,
+                    "currency_id": bill.currency_id.id,
+                    "partner_id": bill.partner_id.id,
+                    "invoice_line_ids": cmd_lines,
+                }
             )
-            base_line_values_list = [
-                line._convert_to_tax_base_line_dict() for line in base_lines
-            ]
-            kwargs = {
-                "base_lines": base_line_values_list,
-                "currency": bill.currency_id or bill.company_id.currency_id,
-            }
-            kwargs["tax_lines"] = [
-                line._convert_to_tax_line_dict()
-                for line in invoice_lines.filtered(
-                    lambda line: line.display_type == "tax"
-                )
-            ]
-            bill.tax_totals = self.env["account.tax"]._prepare_tax_totals(**kwargs)
+            dummy_move._compute_tax_totals()
+            bill.tax_totals = dummy_move.tax_totals
 
     def _update_remit_to_bank_id(self):
         for rec in self:
@@ -193,8 +201,9 @@ class AccountBilling(models.Model):
                 "move_type": "out_invoice",
                 "partner_id": rec.partner_id.id,
                 "date": rec.date,
+                "invoice_date_due": rec.date_due,
                 "invoice_origin": rec.name,
-                "ref": "Tax Adjustment",
+                "ref": f"Tax adjustment for {rec.name}",
                 "is_not_for_billing": True,
                 "line_ids": [],
             }
@@ -206,7 +215,7 @@ class AccountBilling(models.Model):
                 invoice_vals["line_ids"].append(
                     Command.create(
                         {
-                            "name": f"Tax Adjustment for {tax_group.name}",
+                            "name": f"Tax adjustment for {tax_group.name}",
                             "account_id": inv_line_account_id,
                             "quantity": 1,
                             "price_unit": diff,

--- a/l10n_jp_summary_invoice/models/account_move_line.py
+++ b/l10n_jp_summary_invoice/models/account_move_line.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Quartile (https://www.quartile.co)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    # We want to avoid the use of t-esc to manipulate the sign of the quantity in
+    # the report, as it prevents the display adjustments by report_qweb_field_option.
+    signed_quantity = fields.Float(
+        compute="_compute_signed_quantity",
+        digits="Product Unit of Measure",
+        help="Technical field used to display the value with the correct sign in reports.",
+    )
+
+    def _compute_signed_quantity(self):
+        for line in self:
+            sign = -1 if line.move_type in ("out_refund", "in_refund") else 1
+            line.signed_quantity = line.quantity * sign

--- a/l10n_jp_summary_invoice/reports/report_summary_invoice_templates.xml
+++ b/l10n_jp_summary_invoice/reports/report_summary_invoice_templates.xml
@@ -69,7 +69,7 @@
                                 <span t-field="line.name" />
                             </td>
                             <td name="td_quantity" class="text-end">
-                                <span t-field="line.quantity" />
+                                <span t-field="line.signed_quantity" />
                                 <span
                                     t-field="line.product_uom_id"
                                     groups="uom.group_uom"
@@ -91,7 +91,8 @@
                             <td name="td_subtotal" class="text-end">
                                 <span
                                     class="text-nowrap"
-                                    t-field="line.price_subtotal"
+                                    t-esc="line.price_subtotal * (-1 if line.move_type in ['out_refund', 'in_refund'] else 1)"
+                                    t-options='{"widget": "monetary", "display_currency": o.currency_id}'
                                 />
                             </td>
                         </tr>
@@ -114,7 +115,8 @@
                         <td class="text-end">
                             <span
                                 class="text-nowrap"
-                                t-field="invoice.amount_untaxed"
+                                t-esc="invoice.amount_untaxed * (-1 if line.move_type in ['out_refund', 'in_refund'] else 1)"
+                                t-options='{"widget": "monetary", "display_currency": o.currency_id}'
                             />
                         </td>
                     </tr>

--- a/l10n_jp_summary_invoice/tests/test_l10n_jp_summary_invoice.py
+++ b/l10n_jp_summary_invoice/tests/test_l10n_jp_summary_invoice.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Quartile
+# Copyright 2024-2025 Quartile
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.exceptions import ValidationError
@@ -58,13 +58,13 @@ class TestSummaryInvoice(TransactionCase):
             }
         )
 
-    def _create_invoice(self, amount, tax, bank=None):
+    def _create_invoice(self, amount, tax, move_type="out_invoice", bank=None):
         invoice = (
             self.env["account.move"]
             .with_company(self.company)
             .create(
                 {
-                    "move_type": "out_invoice",
+                    "move_type": move_type,
                     "partner_id": self.partner.id,
                     "partner_bank_id": bank and bank.id,
                     "invoice_line_ids": [
@@ -83,6 +83,16 @@ class TestSummaryInvoice(TransactionCase):
         )
         invoice.action_post()
         return invoice
+
+    def _get_billing_tax_amount(self, billing):
+        tax_totals = billing.tax_totals
+        groups_by_subtotal = tax_totals.get("groups_by_subtotal", {})
+        key = next(iter(groups_by_subtotal))
+        tax_group_amount_dict = {
+            entry["tax_group_id"]: entry["tax_group_amount"] * -1
+            for entry in groups_by_subtotal[key]
+        }
+        return round(tax_group_amount_dict.get(self.tax_10.tax_group_id.id, 0), 0)
 
     def test_get_moves_filters_billed_and_flags(self):
         invoice = self._create_invoice(50, self.tax_10)
@@ -146,30 +156,41 @@ class TestSummaryInvoice(TransactionCase):
         self.assertEqual(billing.remit_to_bank_id, self.bank_account)
 
     def test_create_tax_adjustment_entry(self):
-        inv_1 = self._create_invoice(101, self.tax_10)
-        inv_2 = self._create_invoice(102, self.tax_10)
-        inv_3 = self._create_invoice(103, self.tax_10)
-        self.assertEqual(inv_1.amount_tax, 10)
-        self.assertEqual(inv_2.amount_tax, 10)
-        self.assertEqual(inv_3.amount_tax, 10)
-        invoices = inv_1 + inv_2 + inv_3
+        out_inv_1 = self._create_invoice(102, self.tax_10)
+        out_inv_2 = self._create_invoice(102, self.tax_10)
+        out_inv_3 = self._create_invoice(102, self.tax_10)
+        self.assertEqual(out_inv_1.amount_tax, 10)
+        self.assertEqual(out_inv_2.amount_tax, 10)
+        self.assertEqual(out_inv_3.amount_tax, 10)
+        invoices = out_inv_1 + out_inv_2 + out_inv_3
         action = invoices.action_create_billing()
         billing = self.env["account.billing"].browse(action["res_id"])
         self.assertEqual(billing.state, "draft")
         billing.with_company(self.company).validate_billing()
-        tax_totals = billing.tax_totals
-        groups_by_subtotal = tax_totals.get("groups_by_subtotal", {})
-        key = next(iter(groups_by_subtotal))
-        tax_group_amount_dict = {
-            entry["tax_group_id"]: entry["tax_group_amount"] * -1
-            for entry in groups_by_subtotal[key]
-        }
-        billing_tax_amount = round(
-            tax_group_amount_dict.get(self.tax_10.tax_group_id.id, 0), 0
-        )
+        billing_tax_amount = self._get_billing_tax_amount(billing)
+        # The total tax amount should be 31 (306 * 0.1)
         self.assertEqual(abs(billing_tax_amount), 31)
-        tax_adjustment_entry = billing.tax_adjustment_entry_id
-        self.assertTrue(
-            tax_adjustment_entry, "Tax adjustment journal entry should be created."
-        )
-        self.assertEqual(tax_adjustment_entry.amount_total_signed, 1)
+        tax_adj_entry = billing.tax_adjustment_entry_id
+        # Since the total tax amount of the billing (31) is different from the total tax
+        # amount of the invoices (30), a tax adjustment entry should be created.
+        self.assertTrue(tax_adj_entry)
+        self.assertEqual(tax_adj_entry.amount_total_signed, 1)
+        billing.action_cancel()
+        self.assertTrue(tax_adj_entry.state, "cancel")
+        self.assertFalse(billing.tax_adjustment_entry_id)
+        # Add a credit note to the billing
+        out_ref = self._create_invoice(102, self.tax_10, "out_refund")
+        self.assertEqual(out_ref.amount_tax, 10)
+        billing.action_cancel_draft()
+        line_vals = {
+            "move_id": out_ref.id,
+            "amount_total": -out_ref.amount_total,
+            "amount_residual": -out_ref.amount_residual,
+        }
+        billing.write({"billing_line_ids": [Command.create(line_vals)]})
+        self.assertIn(out_ref, billing.billing_line_ids.move_id)
+        billing.with_company(self.company).validate_billing()
+        billing_tax_amount = self._get_billing_tax_amount(billing)
+        # The total tax amount should be 20 (204 * 0.1)
+        self.assertEqual(abs(billing_tax_amount), 20)
+        self.assertFalse(billing.tax_adjustment_entry_id)


### PR DESCRIPTION
This PR adjusts the tax totals computation when out_refund lines are present in billing.
The issue occurred because the `price_unit` of all move lines remained positive, leading to incorrect tax total signs when refunds were included.

@qrtl