### PR TITLE
[16.0][IMP] l10n_jp_summary_invoice: Add the report to the chatter attachments while printing the report

### DIFF
--- a/l10n_jp_summary_invoice/reports/summary_invoice_reports.xml
+++ b/l10n_jp_summary_invoice/reports/summary_invoice_reports.xml
@@ -8,6 +8,10 @@
         <field name="report_file">l10n_jp_summary_invoice.report_summary_invoice</field>
         <field name="binding_model_id" ref="account_billing.model_account_billing" />
         <field name="binding_type">report</field>
+        <field name="attachment_use">True</field>
+        <field
+            name="attachment"
+        >(object.state == 'posted') and ('Summary Invoice-%s' % (object.name))</field>
         <field
             name="print_report_name"
         >'Summary Invoice-%s%s' % (object.name, object.state == 'draft' and '-draft' or '')</field>


### PR DESCRIPTION
- Enabled `attachment_use` and defined `attachment` to store generated reports as PDF files in the chatter when the document state is 'posted'.
- While not a full implementation, conceptually aligns with Japan's Electronic Books Maintenance Act by storing finalized PDF reports in the chatter.

@qrtl QT5504