### PR TITLE
[16.0][FIX] report_alternative_layout: fix displaying information_block twice in normal report

### DIFF
--- a/report_alternative_layout/report/report_template.xml
+++ b/report_alternative_layout/report/report_template.xml
@@ -107,7 +107,7 @@
             <t t-if="apply_alternative_layout and not show_address_in_header">
                 <t t-call="report_alternative_layout.report_custom_address_layout" />
             </t>
-            <t t-if="report">
+            <t t-if="report and apply_alternative_layout">
                 <!-- Show the information block and Remit-to section in the body -->
                 <t t-set="remit_to_bank" t-value="report._get_remit_to_bank(o)" />
                 <div class="row">


### PR DESCRIPTION
The PR fixes the issue of showing information_block twice when the report is not alternative_layout and having information_block in the report.

Steps to reproduce

- Install this module
- Print invoice report

@qrtl QT5614