### PR TITLE
[18.0][FIX] account_move_delivery_invoice: fix hiding tax column in invoice report

### DIFF
--- a/account_move_delivery_invoice/report/report_invoice_document.xml
+++ b/account_move_delivery_invoice/report/report_invoice_document.xml
@@ -2,6 +2,7 @@
     <template
         id="report_invoice_document_inherit_title"
         inherit_id="account.report_invoice_document"
+        priority="99"
     >
         <xpath expr="//t[@t-set='layout_document_title']" position="after">
             <t t-if="o.move_type in ('out_invoice', 'out_refund')">
@@ -18,15 +19,14 @@
             </t>
         </xpath>
         <xpath expr="//th[@name='th_taxes']" position="attributes">
-            <attribute name="t-attf-class">
-                text-end
-                {{ ' d-none d-md-table-cell'
-                if report_type == 'html' or is_delivery_note
-                else '' }}
-            </attribute>
+            <attribute
+                name="t-attf-class"
+            >text-end {{ 'd-none d-md-table-cell' if report_type == 'html' or is_delivery_note else '' }}</attribute>
         </xpath>
-        <xpath expr="//td[@name='td_taxes']" position="attributes">
-            <attribute name="t-if">not is_delivery_note</attribute>
+        <xpath expr="//span[@id='line_tax_ids']/.." position="attributes">
+            <attribute
+                name="t-attf-class"
+            >text-end {{ 'd-none d-md-table-cell' if is_delivery_note else '' }}</attribute>
         </xpath>
         <xpath expr="//div[@id='payment_term']" position="attributes">
             <attribute name="t-if">not is_delivery_note</attribute>


### PR DESCRIPTION
Before this fix, the old pre-commit formatting breaks the behavior and the tax column is also hiding in the invoice report.
This PR is to fix the this issue and add the `priority` to make it not override the module behavior by other modules.

@qrtl QT6181