### PR TITLE
[18.0][FIX] l10n_jp_summary_invoice: use commercial_partner_id for tax adjustment account lookup

### DIFF
--- a/l10n_jp_summary_invoice/models/account_billing.py
+++ b/l10n_jp_summary_invoice/models/account_billing.py
@@ -190,7 +190,7 @@ class AccountBilling(models.Model):
         self.ensure_one()
         return self.env["account.account"]._get_most_frequent_account_for_partner(
             company_id=self.company_id.id,
-            partner_id=self.partner_id.id,
+            partner_id=self.partner_id.commercial_partner_id.id,
             move_type="out_invoice",
         )
 

--- a/l10n_jp_summary_invoice/tests/test_l10n_jp_summary_invoice.py
+++ b/l10n_jp_summary_invoice/tests/test_l10n_jp_summary_invoice.py
@@ -33,6 +33,12 @@ class TestSummaryInvoice(TransactionCase):
                 "property_account_receivable_id": account_receivable.id,
             }
         )
+        cls.child_partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Child Partner",
+                "parent_id": cls.partner.id,
+            }
+        )
         cls.bank_account = cls.env["res.partner.bank"].create(
             {
                 "partner_id": cls.env.company.partner_id.id,
@@ -62,14 +68,16 @@ class TestSummaryInvoice(TransactionCase):
             }
         )
 
-    def _create_invoice(self, amount, tax, move_type="out_invoice", bank=None):
+    def _create_invoice(
+        self, amount, tax, move_type="out_invoice", bank=None, partner=None
+    ):
         invoice = (
             self.env["account.move"]
             .with_company(self.company)
             .create(
                 {
                     "move_type": move_type,
-                    "partner_id": self.partner.id,
+                    "partner_id": (partner or self.partner).id,
                     "partner_bank_id": bank and bank.id,
                     "invoice_line_ids": [
                         Command.create(
@@ -214,3 +222,14 @@ class TestSummaryInvoice(TransactionCase):
         # The total tax amount should be 20 (204 * 0.1)
         self.assertEqual(abs(billing_tax_amount), 20)
         self.assertFalse(billing.tax_adjustment_entry_id)
+
+    def test_create_tax_adjustment_entry_child_partner(self):
+        inv_1 = self._create_invoice(102, self.tax_10, partner=self.child_partner)
+        inv_2 = self._create_invoice(102, self.tax_10, partner=self.child_partner)
+        inv_3 = self._create_invoice(102, self.tax_10, partner=self.child_partner)
+        invoices = inv_1 + inv_2 + inv_3
+        action = invoices.action_create_billing()
+        billing = self.env["account.billing"].browse(action["res_id"])
+        self.assertEqual(billing.partner_id, self.child_partner)
+        billing.with_company(self.company).validate_billing()
+        self.assertTrue(billing.tax_adjustment_entry_id)


### PR DESCRIPTION
When the billing partner is a child contact, account_move_line stores the commercial partner as partner_id. Using partner_id.id directly in _get_inv_line_account_id caused _get_most_frequent_account_for_partner to return False, resulting in account_id=NULL and a DB constraint violation.

@qrtl
QT6561