### PR TITLE
[16.0][FIX] l10n_jp_summary_invoice: improve line name display in report

### DIFF
--- a/l10n_jp_summary_invoice/reports/report_summary_invoice_templates.xml
+++ b/l10n_jp_summary_invoice/reports/report_summary_invoice_templates.xml
@@ -69,7 +69,11 @@
                                 <span t-esc="order.client_order_ref" />
                             </td>
                             <td name="td_description">
-                                <span t-field="line.name" />
+                                <span
+                                    t-if="line.name"
+                                    t-field="line.name"
+                                    t-options="{'widget': 'text'}"
+                                />
                             </td>
                             <td name="td_quantity" class="text-end">
                                 <span t-field="line.signed_quantity" />


### PR DESCRIPTION
Backport of https://github.com/OCA/l10n-japan/pull/119
Add conditional rendering and text widget for the description field to handle empty names and preserve line breaks properly.

@qrtl 5088