### PR TITLE
[18.0][IMP] l10n_jp_summary_invoice: remove billing_line_ids

### DIFF
--- a/l10n_jp_summary_invoice/models/account_move.py
+++ b/l10n_jp_summary_invoice/models/account_move.py
@@ -11,12 +11,6 @@ class AccountMove(models.Model):
     is_not_for_billing = fields.Boolean(
         help="If selected, the invoice is excluded from the billing process.",
     )
-    # TODO: This field should be moved to account_billing module.
-    billing_line_ids = fields.One2many(
-        comodel_name="account.billing.line",
-        inverse_name="move_id",
-        string="Billing Lines",
-    )
     billing_id = fields.Many2one(
         comodel_name="account.billing",
         compute="_compute_billing_id",


### PR DESCRIPTION
Remove `billing_line_ids` since we added it in `account_billing` module.

@qrtl QT6574