### PR TITLE
[19.0][IMP] l10n_jp_address_layout: switch readme to Japanese

### DIFF
--- a/l10n_jp_address_layout/README.rst
+++ b/l10n_jp_address_layout/README.rst
@@ -32,8 +32,8 @@ Japan Address Layout
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module provides the data to switch the address layout of partner
-form to be in Japanese style (postal code -> prefecture -> city...).
+取引先フォームの住所レイアウトを日本式（郵便番号 → 都道府県 →
+市区町村...）に切り替えるためのデータを提供します。
 
 **Table of contents**
 
@@ -43,8 +43,7 @@ form to be in Japanese style (postal code -> prefecture -> city...).
 Usage
 =====
 
-The address layout of the partner form will appear as shown in the image
-below when your company's country is set to Japan.
+自社の国を日本に設定すると、取引先フォームの住所レイアウトが下図のように表示されます。
 
 |image1|
 
@@ -87,6 +86,17 @@ This module is maintained by the OCA.
 OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
+
+.. |maintainer-yostashiro| image:: https://github.com/yostashiro.png?size=40px
+    :target: https://github.com/yostashiro
+    :alt: yostashiro
+.. |maintainer-AungKoKoLin1997| image:: https://github.com/AungKoKoLin1997.png?size=40px
+    :target: https://github.com/AungKoKoLin1997
+    :alt: AungKoKoLin1997
+
+Current `maintainers <https://odoo-community.org/page/maintainer-role>`__:
+
+|maintainer-yostashiro| |maintainer-AungKoKoLin1997| 
 
 This module is part of the `OCA/l10n-japan <https://github.com/OCA/l10n-japan/tree/19.0/l10n_jp_address_layout>`_ project on GitHub.
 

--- a/l10n_jp_address_layout/__manifest__.py
+++ b/l10n_jp_address_layout/__manifest__.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     "name": "Japan Address Layout",
+    "summary": "取引先の住所レイアウトを日本式に切替",
     "version": "19.0.1.0.0",
     "depends": ["web"],
     "author": "Quartile, Odoo Community Association (OCA)",
@@ -13,4 +14,5 @@
         "data/res_country_data.xml",
     ],
     "installable": True,
+    "maintainers": ["yostashiro", "AungKoKoLin1997"],
 }

--- a/l10n_jp_address_layout/readme/DESCRIPTION.md
+++ b/l10n_jp_address_layout/readme/DESCRIPTION.md
@@ -1,2 +1,1 @@
-This module provides the data to switch the address layout of partner
-form to be in Japanese style (postal code -\> prefecture -\> city...).
+取引先フォームの住所レイアウトを日本式（郵便番号 → 都道府県 → 市区町村...）に切り替えるためのデータを提供します。

--- a/l10n_jp_address_layout/readme/USAGE.md
+++ b/l10n_jp_address_layout/readme/USAGE.md
@@ -1,4 +1,3 @@
-The address layout of the partner form will appear as shown in the image below when
-your company's country is set to Japan.
+自社の国を日本に設定すると、取引先フォームの住所レイアウトが下図のように表示されます。
 
 ![](../static/description/japan_address_layout.png)

--- a/l10n_jp_address_layout/static/description/index.html
+++ b/l10n_jp_address_layout/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -363,9 +362,7 @@ ul.auto-toc {
 <div class="document">
 
 
-<a class="reference external image-reference" href="https://odoo-community.org/get-involved?utm_source=readme">
-<img alt="Odoo Community Association" src="https://odoo-community.org/readme-banner-image" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org/get-involved?utm_source=readme"><img alt="Odoo Community Association" src="https://odoo-community.org/readme-banner-image" /></a>
 <div class="section" id="japan-address-layout">
 <h1>Japan Address Layout</h1>
 <!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -375,8 +372,8 @@ ul.auto-toc {
 !! source digest: sha256:625995a6f70d0a6cf139ea72fb7decdc7987f0883738b4950c1ead4b7edd1295
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/l10n-japan/tree/19.0/l10n_jp_address_layout"><img alt="OCA/l10n-japan" src="https://img.shields.io/badge/github-OCA%2Fl10n--japan-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/l10n-japan-19-0/l10n-japan-19-0-l10n_jp_address_layout"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/l10n-japan&amp;target_branch=19.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module provides the data to switch the address layout of partner
-form to be in Japanese style (postal code -&gt; prefecture -&gt; city…).</p>
+<p>取引先フォームの住所レイアウトを日本式（郵便番号 → 都道府県 →
+市区町村…）に切り替えるためのデータを提供します。</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -392,8 +389,7 @@ form to be in Japanese style (postal code -&gt; prefecture -&gt; city…).</p>
 </div>
 <div class="section" id="usage">
 <h2><a class="toc-backref" href="#toc-entry-1">Usage</a></h2>
-<p>The address layout of the partner form will appear as shown in the image
-below when your company’s country is set to Japan.</p>
+<p>自社の国を日本に設定すると、取引先フォームの住所レイアウトが下図のように表示されます。</p>
 <p><img alt="image1" src="https://raw.githubusercontent.com/OCA/l10n-japan/19.0/l10n_jp_address_layout/static/description/japan_address_layout.png" /></p>
 </div>
 <div class="section" id="bug-tracker">
@@ -423,12 +419,12 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h3><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
+<p>Current <a class="reference external" href="https://odoo-community.org/page/maintainer-role">maintainers</a>:</p>
+<p><a class="reference external image-reference" href="https://github.com/yostashiro"><img alt="yostashiro" src="https://github.com/yostashiro.png?size=40px" /></a> <a class="reference external image-reference" href="https://github.com/AungKoKoLin1997"><img alt="AungKoKoLin1997" src="https://github.com/AungKoKoLin1997.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/OCA/l10n-japan/tree/19.0/l10n_jp_address_layout">OCA/l10n-japan</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>


### PR DESCRIPTION
Switch the README contents to Japanese and set maintainers.

- Translate `readme/DESCRIPTION.md` and `readme/USAGE.md`
- Add Japanese `summary` and `maintainers` in `__manifest__.py`
- Regenerate `README.rst` and `static/description/index.html`

@qrtl QT6740