### PR TITLE
[18.0][IMP] l10n_jp_summary_invoice: handle rounding diff in summary invoice

### DIFF
--- a/l10n_jp_summary_invoice/models/account_billing.py
+++ b/l10n_jp_summary_invoice/models/account_billing.py
@@ -39,6 +39,7 @@ class AccountBilling(models.Model):
         store=True,
     )
     tax_adjustment_entry_id = fields.Many2one("account.move")
+    untaxed_adjustment_entry_id = fields.Many2one("account.move")
     company_partner_id = fields.Many2one(
         related="company_id.partner_id", string="Company Partner", store=True
     )
@@ -204,9 +205,33 @@ class AccountBilling(models.Model):
             move_type="out_invoice",
         )
 
+    def _create_adjustment_entry(self, ref, line_vals_list):
+        """Create, post, and return an adjustment journal entry."""
+        self.ensure_one()
+        is_refund = sum(vals.get("price_unit", 0) for vals in line_vals_list) < 0
+        if is_refund:
+            line_vals_list = [
+                {**vals, "price_unit": -vals.get("price_unit", 0)}
+                for vals in line_vals_list
+            ]
+        adjustment_move = self.env["account.move"].create(
+            {
+                "move_type": "out_refund" if is_refund else "out_invoice",
+                "partner_id": self.partner_id.id,
+                "currency_id": self.currency_id.id,
+                "date": self.date,
+                "invoice_origin": self.name,
+                "ref": ref,
+                "is_not_for_billing": True,
+                "line_ids": [Command.create(vals) for vals in line_vals_list],
+            }
+        )
+        adjustment_move.action_post()
+        return adjustment_move
+
     def validate_billing(self):
         res = super().validate_billing()
-        # Tax journal entry will be created only for customer invoice billings.
+        # Adjustment entries will be created only for customer invoice billings.
         for rec in self.filtered(lambda x: x.bill_type == "out_invoice"):
             tax_totals = rec.tax_totals
             if not tax_totals:
@@ -226,25 +251,23 @@ class AccountBilling(models.Model):
                 tax_diff = tax_amount_invoices - tax_amount_bill
                 if not rec.currency_id.is_zero(tax_diff):
                     tax_group_diff_dict[tax_group_id] = tax_diff
-            if not tax_group_diff_dict:
+            # --- Compute untaxed diff ---
+            src_moves = rec.billing_line_ids.move_id
+            sum_invoices_untaxed = sum(
+                inv.amount_untaxed * (-inv.direction_sign) for inv in src_moves
+            )
+            untaxed_diff = rec.amount_untaxed - sum_invoices_untaxed
+            has_untaxed_diff = not rec.currency_id.is_zero(untaxed_diff)
+            if not tax_group_diff_dict and not has_untaxed_diff:
                 continue
-            invoice_vals = {
-                "move_type": "out_invoice",
-                "partner_id": rec.partner_id.id,
-                "currency_id": rec.currency_id.id,
-                "date": rec.date,
-                "invoice_origin": rec.name,
-                "ref": f"Tax adjustment for {rec.name}",
-                "is_not_for_billing": True,
-                "line_ids": [],
-            }
             inv_line_account_id = rec._get_inv_line_account_id()
-            diff_balance = 0.0
-            for tax_group_id, diff in tax_group_diff_dict.items():
-                tax_group = self.env["account.tax.group"].browse(tax_group_id)
-                adjustment_tax = tax_group._get_adjustment_tax()
-                invoice_vals["line_ids"].append(
-                    Command.create(
+            # --- Create tax adjustment entry ---
+            if tax_group_diff_dict:
+                line_vals_list = []
+                for tax_group_id, diff in tax_group_diff_dict.items():
+                    tax_group = self.env["account.tax.group"].browse(tax_group_id)
+                    adjustment_tax = tax_group._get_adjustment_tax()
+                    line_vals_list.append(
                         {
                             "name": f"Tax adjustment for {tax_group.name}",
                             "account_id": inv_line_account_id,
@@ -253,13 +276,23 @@ class AccountBilling(models.Model):
                             "tax_ids": [Command.set(adjustment_tax.ids)],
                         },
                     )
+                rec.tax_adjustment_entry_id = rec._create_adjustment_entry(
+                    f"Tax adjustment for {rec.name}", line_vals_list
                 )
-                diff_balance += diff
-            adjustment_move = self.env["account.move"].create(invoice_vals)
-            if diff_balance < 0:
-                adjustment_move.action_switch_move_type()
-            adjustment_move.action_post()
-            rec.tax_adjustment_entry_id = adjustment_move
+            # --- Create untaxed adjustment entry ---
+            if has_untaxed_diff:
+                rec.untaxed_adjustment_entry_id = rec._create_adjustment_entry(
+                    f"Untaxed amount adjustment for {rec.name}",
+                    [
+                        {
+                            "name": f"Untaxed amount adjustment for {rec.name}",
+                            "account_id": inv_line_account_id,
+                            "quantity": 1,
+                            "price_unit": untaxed_diff,
+                            "tax_ids": [Command.set([])],
+                        }
+                    ],
+                )
         return res
 
     def action_cancel(self):
@@ -268,4 +301,7 @@ class AccountBilling(models.Model):
             rec.tax_adjustment_entry_id.button_draft()
             rec.tax_adjustment_entry_id.button_cancel()
             rec.tax_adjustment_entry_id = False
+            rec.untaxed_adjustment_entry_id.button_draft()
+            rec.untaxed_adjustment_entry_id.button_cancel()
+            rec.untaxed_adjustment_entry_id = False
         return res

--- a/l10n_jp_summary_invoice/tests/test_l10n_jp_summary_invoice.py
+++ b/l10n_jp_summary_invoice/tests/test_l10n_jp_summary_invoice.py
@@ -256,6 +256,56 @@ class TestSummaryInvoice(TransactionCase):
         self.assertFalse(inv1.billing_id)
         self.assertFalse(inv2.billing_id)
 
+    def test_create_untaxed_adjustment_entry(self):
+        """3 invoices at 100.3 JPY: only untaxed rounding diff, no tax diff."""
+        inv_1 = self._create_invoice(100.3, self.tax_10)
+        inv_2 = self._create_invoice(100.3, self.tax_10)
+        inv_3 = self._create_invoice(100.3, self.tax_10)
+        # Each invoice: amount_untaxed = round(100.3) = 100
+        self.assertEqual(inv_1.amount_untaxed, 100)
+        # Each invoice: tax = round(100.3 * 0.1) = round(10.03) = 10
+        self.assertEqual(inv_1.amount_tax, 10)
+        invoices = inv_1 + inv_2 + inv_3
+        action = invoices.action_create_billing()
+        billing = self.env["account.billing"].browse(action["res_id"])
+        billing.with_company(self.company).validate_billing()
+        # Billing: amount_untaxed = round(300.9) = 301
+        self.assertEqual(billing.amount_untaxed, 301)
+        # No tax adjustment: billing tax = round(30.09) = 30, invoices tax = 30
+        self.assertFalse(billing.tax_adjustment_entry_id)
+        # Untaxed adjustment: 301 - 300 = 1
+        untaxed_adj = billing.untaxed_adjustment_entry_id
+        self.assertTrue(untaxed_adj)
+        self.assertEqual(untaxed_adj.amount_total_signed, 1)
+        # Cancel and verify cleanup
+        billing.action_cancel()
+        self.assertEqual(untaxed_adj.state, "cancel")
+        self.assertFalse(billing.untaxed_adjustment_entry_id)
+
+    def test_create_both_adjustment_entries(self):
+        """3 invoices at 102.5 JPY: both tax and untaxed rounding diffs."""
+        inv_1 = self._create_invoice(102.5, self.tax_10)
+        inv_2 = self._create_invoice(102.5, self.tax_10)
+        inv_3 = self._create_invoice(102.5, self.tax_10)
+        # Each invoice: amount_untaxed = round(102.5) = 103
+        self.assertEqual(inv_1.amount_untaxed, 103)
+        # Each invoice: tax = round(10.25) = 10
+        self.assertEqual(inv_1.amount_tax, 10)
+        invoices = inv_1 + inv_2 + inv_3
+        action = invoices.action_create_billing()
+        billing = self.env["account.billing"].browse(action["res_id"])
+        billing.with_company(self.company).validate_billing()
+        # Billing: amount_untaxed = round(307.5) = 308
+        self.assertEqual(billing.amount_untaxed, 308)
+        # Tax adjustment: billing tax = round(30.75) = 31, invoices tax = 30, diff = 1
+        tax_adj = billing.tax_adjustment_entry_id
+        self.assertTrue(tax_adj)
+        self.assertEqual(tax_adj.amount_total_signed, 1)
+        # Untaxed adjustment: 308 - 309 = -1 (credit note)
+        untaxed_adj = billing.untaxed_adjustment_entry_id
+        self.assertTrue(untaxed_adj)
+        self.assertEqual(untaxed_adj.amount_total_signed, -1)
+
     def test_check_tax_adjustment_with_currency_rounding_issue(self):
         self.assertEqual(self.env.company.currency_id, self.env.ref("base.JPY"))
         currency_usd = self.env.ref("base.USD")

--- a/l10n_jp_summary_invoice/views/account_billing_views.xml
+++ b/l10n_jp_summary_invoice/views/account_billing_views.xml
@@ -72,12 +72,21 @@
             </xpath>
             <xpath expr="//notebook" position="inside">
                 <page
-                    string="Tax Adjustment"
-                    invisible="tax_adjustment_entry_id == False"
+                    string="Adjustments"
+                    invisible="not tax_adjustment_entry_id and not untaxed_adjustment_entry_id"
                 >
                     <group>
                         <group>
-                            <field name="tax_adjustment_entry_id" readonly="1" />
+                            <field
+                                name="tax_adjustment_entry_id"
+                                readonly="1"
+                                invisible="not tax_adjustment_entry_id"
+                            />
+                            <field
+                                name="untaxed_adjustment_entry_id"
+                                readonly="1"
+                                invisible="not untaxed_adjustment_entry_id"
+                            />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
Address the rounding mismatch between invoice line subtotals and invoice untaxed totals under "Round Globally" with zero-decimal currencies (e.g. JPY), as reported in odoo/odoo#265433.

- Add untaxed_adjustment_entry_id to create a separate adjustment entry when the sum of original invoices' untaxed amounts differs from the billing's recalculated untaxed total.
- Extract _create_adjustment_entry() to share logic between tax and untaxed adjustment entry creation.
- Use price_unit * quantity in the summary invoice report subtotal column with "Product Price" decimal precision, avoiding the currency-rounded price_subtotal.

@qrtl QT6785