### PR TITLE
[FIX] l10n_jp_summary_invoice: Create tax adjustment entry for vendor bill billings

### DIFF
--- a/l10n_jp_summary_invoice/models/account_billing.py
+++ b/l10n_jp_summary_invoice/models/account_billing.py
@@ -176,7 +176,7 @@ class AccountBilling(models.Model):
                 )
         res = super().validate_billing()
         # Tax journal entry will be created only for customer invoice billings.
-        for rec in self.filtered(lambda x: x.bill_type == "out_invoice"):
+        for rec in self.filtered(lambda x: x.bill_type in ["out_invoice", "in_invoice"]):
             tax_totals = rec.tax_totals
             groups_by_subtotal = tax_totals.get("groups_by_subtotal", {})
             if not groups_by_subtotal:


### PR DESCRIPTION
Previously, tax adjustment entries were only created for customer invoice billings (out_invoice). Vendor bill billings (in_invoice) can also have rounding differences between individual invoice taxes and the consolidated tax amount, so extend the logic to handle them as well.

@qrtl
QT6947