### PR TITLE
[18.0][FIX] l10n_jp_summary_invoice: billing totals language and duplicate footer

### DIFF
--- a/l10n_jp_summary_invoice/models/account_billing.py
+++ b/l10n_jp_summary_invoice/models/account_billing.py
@@ -20,23 +20,7 @@ class AccountBilling(models.Model):
     tax_totals = fields.Json(
         string="Billing Totals",
         compute="_compute_tax_totals",
-        store=True,
         exportable=False,
-    )
-    amount_untaxed = fields.Monetary(
-        string="Untaxed Amount",
-        compute="_compute_tax_totals",
-        store=True,
-    )
-    amount_tax = fields.Monetary(
-        string="Tax Amount",
-        compute="_compute_tax_totals",
-        store=True,
-    )
-    amount_total = fields.Monetary(
-        string="Total Amount",
-        compute="_compute_tax_totals",
-        store=True,
     )
     tax_adjustment_entry_id = fields.Many2one("account.move")
     company_partner_id = fields.Many2one(
@@ -101,6 +85,11 @@ class AccountBilling(models.Model):
         """Compute `tax_totals` by building an in-memory draft invoice that reuses all
         the invoice lines referenced by the billing lines, and then delegating the tax
         calculation to Odoo's standard `account.move._compute_tax_totals()`.
+
+        As in `account.move`, the field is not stored: the labels it holds (e.g.
+        "Untaxed Amount", tax group names) are translated when the value is built, so
+        it has to be built in the language of the reader (i.e. the partner's one in the
+        report).
         """
         for bill in self:
             bill.tax_totals = self.env["account.tax"]._get_tax_totals_summary(
@@ -108,9 +97,6 @@ class AccountBilling(models.Model):
                 currency=bill.currency_id or bill.company_id.currency_id,
                 company=bill.company_id,
             )
-            bill.amount_untaxed = 0.0
-            bill.amount_tax = 0.0
-            bill.amount_total = 0.0
             src_moves = bill.billing_line_ids.move_id
             if not src_moves:
                 continue
@@ -135,10 +121,16 @@ class AccountBilling(models.Model):
             )
             dummy_move._compute_tax_totals()
             bill.tax_totals = dummy_move.tax_totals
-            if bill.tax_totals:
-                bill.amount_untaxed = bill.tax_totals.get("base_amount_currency", 0.0)
-                bill.amount_total = bill.tax_totals.get("total_amount_currency", 0.0)
-                bill.amount_tax = bill.amount_total - bill.amount_untaxed
+
+    @api.depends("billing_line_ids", "partner_id", "currency_id")
+    def _compute_amount(self):
+        super()._compute_amount()
+        for bill in self:
+            tax_totals = bill.tax_totals or {}
+            bill.amount_untaxed = tax_totals.get("base_amount_currency", 0.0)
+            bill.amount_total = tax_totals.get("total_amount_currency", 0.0)
+            bill.amount_tax = bill.amount_total - bill.amount_untaxed
+        return
 
     def _update_remit_to_bank_id(self):
         for rec in self:

--- a/l10n_jp_summary_invoice/views/account_billing_views.xml
+++ b/l10n_jp_summary_invoice/views/account_billing_views.xml
@@ -57,6 +57,13 @@
             <xpath expr="//field[@name='date']" position="after">
                 <field name="date_due" invisible="bill_type != 'out_invoice'" />
             </xpath>
+            <!-- Hide the standard totals footer, replaced below by one showing the
+                 tax totals widget, which breaks the amounts down per tax. This has to
+                 come first: the group added below carries the same class, and would
+                 otherwise be the one matched here. -->
+            <xpath expr="//group[hasclass('oe_subtotal_footer')]" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
             <xpath expr="//field[@name='billing_line_ids']" position="after">
                 <group>
                     <group class="oe_subtotal_footer">


### PR DESCRIPTION
Depends on https://github.com/OCA/account-invoicing/pull/2439

Two fixes:

- The labels held by `tax_totals` (e.g. "Untaxed Amount", tax group names) are translated when the value is built, so storing the field freezes them in the language of the user who triggered the compute, and the report cannot translate them anymore. The field is no longer stored, as in `account.move`, so that it is built in the language of the reader (i.e. the partner's one in the report). The amount fields have to stay stored, hence they move to `_compute_amount` — sharing a compute method with a non-stored field would update them on each read.
- `account_billing` shows `amount_untaxed`, `amount_tax` and `amount_total` in a totals footer of its own since 18.0.1.5.0, so the form ended up with two footers. The standard one is hidden and `amount_due` moved next to the tax totals widget, which already breaks the other three amounts down per tax. The three amount fields are no longer declared here either, as `account_billing` declares them itself.

Assisted-by: Claude Opus 5

@qrtl QT7203